### PR TITLE
Add support for bright/light variants of colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,13 @@ var styles = {
   cyan: [36, 39],
   white: [37, 39],
   gray: [90, 39],
+  lightRed: [91, 39],
+  lightGreen: [92, 39],
+  lightYellow: [93, 39],
+  lightBlue: [94, 39],
+  lightMagenta: [95, 39],
+  lightCyan: [96, 39],
+  lightWhite: [97, 39],
   bgBlack: [40, 49],
   bgRed: [41, 49],
   bgGreen: [42, 49],
@@ -41,7 +48,15 @@ var styles = {
   bgBlue: [44, 49],
   bgMagenta: [45, 49],
   bgCyan: [46, 49],
-  bgWhite: [47, 49]
+  bgWhite: [47, 49],
+  bgGray: [100, 49],
+  bgLightRed: [101, 49],
+  bgLightGreen: [102, 49],
+  bgLightYellow: [103, 49],
+  bgLightBlue: [104, 49],
+  bgLightMagenta: [105, 49],
+  bgLightCyan: [106, 49],
+  bgLightWhite: [107, 49],
 };
 
 var code_to_style = {};


### PR DESCRIPTION
Thanks for this great package!

This PR adds support for the light variants of the 8 ANSI colors. Note the table here: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors

These colors aren't supported by chalk, so I couldn't add tests for the new colors without pulling in another dependency, but I did briefly verify that the parser picks up these new colors by running some console output through it.